### PR TITLE
fix: illegal syntax in path

### DIFF
--- a/backend/bonita/celery_tasks/tasks.py
+++ b/backend/bonita/celery_tasks/tasks.py
@@ -21,7 +21,7 @@ from bonita.modules.scraping.scraping import add_mark, process_nfo_file, process
 from bonita.utils.fileinfo import BasicFileInfo, TargetFileInfo
 from bonita.modules.transfer.transfer import transSingleFile, transferfile
 from bonita.utils.downloader import process_cached_file, update_cache_from_local
-from bonita.utils.filehelper import cleanFolderWithoutSuffix, findAllFilesWithSuffix, video_type
+from bonita.utils.filehelper import cleanFolderWithoutSuffix, findAllFilesWithSuffix, sanitize_path, video_type
 from bonita.utils.http import get_active_proxy
 from bonita.modules.media_service.emby import EmbyService
 from bonita.celery_tasks.decorators import manage_celery_task
@@ -308,8 +308,8 @@ def celery_scrapping(self, file_path, scraping_dict):
             shorttitle = metadata_mixed.title[0:maxlen]
             extra_folder = extra_folder.replace(metadata_mixed.title, shorttitle)
             extra_name = extra_name.replace(metadata_mixed.title, shorttitle)
-        metadata_mixed.extra_folder = extra_folder
-        metadata_mixed.extra_filename = extra_name
+        metadata_mixed.extra_folder = sanitize_path(extra_folder)
+        metadata_mixed.extra_filename = sanitize_path(extra_name)
 
         # 将 extrainfo.tag 中的标签添加到 metadata_base.tag 中，过滤重复的标签
         existing_tags = set(metadata_mixed.tag.split(", "))

--- a/backend/bonita/utils/filehelper.py
+++ b/backend/bonita/utils/filehelper.py
@@ -293,3 +293,13 @@ def is_video_file(filepath: str) -> bool:
     if not is_video:
         logger.debug(f"File {filepath} is not a video file")
     return is_video
+
+def sanitize_path(name: str) -> str:
+    """
+    清理字符串，使其可以作为合法的文件名或目录名。
+    将Windows和Linux/macOS上非法的字符替换为下划线。
+    """
+    if not name:
+        return ""
+    # 替换在路径中非法的字符
+    return re.sub(r'[\\/:*?"<>|]', '_', name)


### PR DESCRIPTION
It is possible that illegal syntax exists in filename then causes wrong path generation.  
eg: DLDSS-064  
scrapted filename: "人妻あやかの告白/野獣に凌●を受け種付けされた私は… 友田彩也香"  
you can see there is a "/" in filename, then bonita will create wrong folder.  


When I run ```docker build .``` It says ```Dockerfile:66
ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref 11299f82-d2a8-468b-87fb-5e538c407b06::dod4xx50xksgahu0w94qnr5ir: "/docker/s6-rc.d": not found```
I cannot test locally, please help to check if my code is working.