### PR TITLE
加入封面重试机制

### DIFF
--- a/backend/bonita/celery_tasks/tasks.py
+++ b/backend/bonita/celery_tasks/tasks.py
@@ -277,9 +277,15 @@ def celery_transfer_group(self, task_json, full_path, isEntry=False):
                         except Exception as e:
                             logger.warning(f"      ⊘ extrafanart 下载失败: {e}")
 
-                    # 更新 metadata_mixed 中的 cover 为实际使用的 URL
+                    # 更新 metadata_mixed 中的 cover 为实际使用的 URL，同时回写数据库
                     if cover_url:
                         metamixed.cover = cover_url
+                        metadata_record = session.query(Metadata).filter(
+                            Metadata.number == metamixed.number
+                        ).order_by(Metadata.id.desc()).first()
+                        if metadata_record:
+                            metadata_record.cover = cover_url
+                            session.commit()
 
                     # 有封面则处理封面图片，否则跳过
                     pics = []

--- a/backend/bonita/celery_tasks/tasks.py
+++ b/backend/bonita/celery_tasks/tasks.py
@@ -212,6 +212,7 @@ def celery_transfer_group(self, task_json, full_path, isEntry=False):
                     process_nfo_file(output_folder, metamixed.extra_filename, metamixed.__dict__)
 
                     # 尝试下载封面，最多重试5次
+                    proxy = get_active_proxy(session)
                     cache_cover_filepath = None
                     cover_url = metamixed.cover
                     retry_count = 0

--- a/backend/bonita/celery_tasks/tasks.py
+++ b/backend/bonita/celery_tasks/tasks.py
@@ -219,6 +219,12 @@ def celery_transfer_group(self, task_json, full_path, isEntry=False):
                     used_sources = {metamixed.site} if metamixed.site else set()
                     extrafanart_list = []
 
+                    # 收集首次刮削拿到的 extrafanart
+                    raw_ef = metamixed.extrafanart or ''
+                    if raw_ef:
+                        ef_items = raw_ef.split(',') if isinstance(raw_ef, str) else raw_ef
+                        extrafanart_list = [u.strip() for u in ef_items if u.strip()]
+
                     while retry_count < max_retries:
                         try:
                             cache_cover_filepath = process_cached_file(session, cover_url, metamixed.number)
@@ -229,14 +235,12 @@ def celery_transfer_group(self, task_json, full_path, isEntry=False):
                             if retry_count >= max_retries:
                                 break
                             # 用其他源重新刮削获取封面 URL
-                            remaining_sources = [
-                                s for s in (scraping_conf.scraping_sites.split(',') if scraping_conf.scraping_sites else [])
-                                if s.strip() not in used_sources
-                            ]
+                            all_sources = scraping_conf.scraping_sites.split(',') if scraping_conf.scraping_sites else []
+                            remaining_sources = [s.strip() for s in all_sources if s.strip() and s.strip() not in used_sources]
                             if not remaining_sources:
                                 logger.warning(f"      ⊘ 没有可用源可继续尝试")
                                 break
-                            # 指定第一个未用过的源，保留其他参数
+                            # 指定第一个未用过的源重新刮削
                             fallback_json = scraping(
                                 metamixed.number,
                                 sources=','.join(remaining_sources[:1]),
@@ -248,14 +252,14 @@ def celery_transfer_group(self, task_json, full_path, isEntry=False):
                                 new_site = fallback_json.get('source', '')
                                 if new_site:
                                     used_sources.add(new_site)
-                                # 收集 extrafanart（无论封面是否成功都收集）
-                                if fallback_json.get('extrafanart'):
-                                    existing = extrafanart_list
-                                    ef = fallback_json['extrafanart']
-                                    if isinstance(ef, list):
-                                        extrafanart_list = existing + [u for u in ef if u not in existing]
-                                    elif ef not in existing:
-                                        extrafanart_list.append(ef)
+                                # 收集 extrafanart
+                                ef_raw = fallback_json.get('extrafanart')
+                                if ef_raw:
+                                    ef_items = ef_raw.split(',') if isinstance(ef_raw, str) else ef_raw
+                                    for u in ef_items:
+                                        u = u.strip()
+                                        if u and u not in extrafanart_list:
+                                            extrafanart_list.append(u)
                                 new_cover = fallback_json.get('cover')
                                 if new_cover and new_cover != cover_url:
                                     cover_url = new_cover

--- a/backend/bonita/celery_tasks/tasks.py
+++ b/backend/bonita/celery_tasks/tasks.py
@@ -20,7 +20,7 @@ from bonita.modules.scraping.number_parser import FileNumInfo
 from bonita.modules.scraping.scraping import add_mark, need_crop, process_nfo_file, process_cover, scraping, load_all_NFO_from_folder
 from bonita.utils.fileinfo import BasicFileInfo, TargetFileInfo
 from bonita.modules.transfer.transfer import transSingleFile, transferfile
-from bonita.utils.downloader import process_cached_file, update_cache_from_local
+from bonita.utils.downloader import process_cached_file, download_file, update_cache_from_local
 from bonita.utils.filehelper import cleanFolderWithoutSuffix, findAllFilesWithSuffix, video_type
 from bonita.utils.http import get_active_proxy
 from bonita.modules.media_service.emby import EmbyService
@@ -210,10 +210,80 @@ def celery_transfer_group(self, task_json, full_path, isEntry=False):
                         os.makedirs(output_folder)
                     # 更新NFO文件/cover
                     process_nfo_file(output_folder, metamixed.extra_filename, metamixed.__dict__)
-                    cache_cover_filepath = process_cached_file(session, metamixed.cover, metamixed.number)
-                    pics = process_cover(cache_cover_filepath, output_folder, metamixed.extra_filename, crop=metamixed.extra_crop)
-                    if scraping_conf.watermark_enabled:
-                        add_mark(pics, metamixed.tag, scraping_conf.watermark_location, scraping_conf.watermark_size)
+
+                    # 尝试下载封面，最多重试5次
+                    cache_cover_filepath = None
+                    cover_url = metamixed.cover
+                    retry_count = 0
+                    max_retries = 5
+                    used_sources = {metamixed.site} if metamixed.site else set()
+                    extrafanart_list = []
+
+                    while retry_count < max_retries:
+                        try:
+                            cache_cover_filepath = process_cached_file(session, cover_url, metamixed.number)
+                            break
+                        except Exception as e:
+                            retry_count += 1
+                            logger.warning(f"      ✗ 封面下载失败 (尝试 {retry_count}/{max_retries}): {cover_url} — {e}")
+                            if retry_count >= max_retries:
+                                break
+                            # 用其他源重新刮削获取封面 URL
+                            remaining_sources = [
+                                s for s in (scraping_conf.scraping_sites.split(',') if scraping_conf.scraping_sites else [])
+                                if s.strip() not in used_sources
+                            ]
+                            if not remaining_sources:
+                                logger.warning(f"      ⊘ 没有可用源可继续尝试")
+                                break
+                            # 指定第一个未用过的源，保留其他参数
+                            fallback_json = scraping(
+                                metamixed.number,
+                                sources=','.join(remaining_sources[:1]),
+                                specifiedsource="",
+                                specifiedurl="",
+                                proxy=proxy
+                            )
+                            if fallback_json and fallback_json.get('cover'):
+                                new_site = fallback_json.get('source', '')
+                                if new_site:
+                                    used_sources.add(new_site)
+                                # 收集 extrafanart（无论封面是否成功都收集）
+                                if fallback_json.get('extrafanart'):
+                                    existing = extrafanart_list
+                                    ef = fallback_json['extrafanart']
+                                    if isinstance(ef, list):
+                                        extrafanart_list = existing + [u for u in ef if u not in existing]
+                                    elif ef not in existing:
+                                        extrafanart_list.append(ef)
+                                new_cover = fallback_json.get('cover')
+                                if new_cover and new_cover != cover_url:
+                                    cover_url = new_cover
+                                    continue
+                            break
+
+                    # 全部重试失败，降级到 extrafanart
+                    if cache_cover_filepath is None and extrafanart_list:
+                        ef_url = extrafanart_list[0]
+                        logger.info(f"      → 使用 extrafanart 作为封面: {ef_url}")
+                        try:
+                            cache_cover_filepath = download_file(ef_url, metamixed.number, proxy)
+                            cover_url = ef_url
+                        except Exception as e:
+                            logger.warning(f"      ⊘ extrafanart 下载失败: {e}")
+
+                    # 更新 metadata_mixed 中的 cover 为实际使用的 URL
+                    if cover_url:
+                        metamixed.cover = cover_url
+
+                    # 有封面则处理封面图片，否则跳过
+                    pics = []
+                    if cache_cover_filepath:
+                        pics = process_cover(cache_cover_filepath, output_folder, metamixed.extra_filename, crop=metamixed.extra_crop)
+                        if scraping_conf.watermark_enabled:
+                            add_mark(pics, metamixed.tag, scraping_conf.watermark_location, scraping_conf.watermark_size)
+                    else:
+                        logger.warning(f"      ⊘ 封面获取失败，跳过封面图片处理")
                     # 移动
                     destpath = transSingleFile(original_file, output_folder,
                                                metamixed.extra_filename, task_info.operation)


### PR DESCRIPTION
最近在刮削的时候总是遇到一个问题，当刮削数据从javbus刮削到的时候，封面图片url无法下载，javbus会返回403，于是加了一个图片封面重试机制，下面是用ai总结的本次更改
# 封面下载重试机制

## 改动文件

- `backend/bonita/celery_tasks/tasks.py`

## 改动概述

当刮削时封面图片下载失败，不再直接导致整个刮削失败，而是进入重试流程：尝试用其他源重新刮削获取封面 URL，失败后降级到使用 extrafanart 图片，最终无论封面获取结果如何，文件操作（NFO、转移）都会正常执行。

## 详细改动

### 1. 新增 import

```diff
from bonita.utils.downloader import process_cached_file, update_cache_from_local
+from bonita.utils.downloader import process_cached_file, download_file, update_cache_from_local
```

新增 `download_file` 的导入，供 extrafanart 降级时直接下载图片使用。

### 2. 封面重试逻辑（`celery_transfer_group` 函数内）

#### 2.1 变量初始化

```python
proxy = get_active_proxy(session)          # 获取代理
cache_cover_filepath = None              # 缓存封面路径
cover_url = metamixed.cover              # 当前尝试的封面 URL
retry_count = 0                          # 当前重试次数
max_retries = 5                          # 最大重试次数（硬编码）
used_sources = {metamixed.site}          # 已用过的刮削源
extrafanart_list = []                    # 收集到的 extrafanart URL 列表
```

#### 2.2 收集首次刮削的 extrafanart

```python
raw_ef = metamixed.extrafanart or ''
if raw_ef:
    ef_items = raw_ef.split(',') if isinstance(raw_ef, str) else raw_ef
    extrafanart_list = [u.strip() for u in ef_items if u.strip()]
```

在进入重试循环前，先将首次刮削获取的 extrafanart 收集进来，确保即使没有可重试的源也能走降级逻辑。

#### 2.3 重试循环（最多 5 次）

```
while retry_count < max_retries:
    try:
        # 尝试下载封面（走缓存逻辑）
        cache_cover_filepath = process_cached_file(session, cover_url, ...)
        break  # 成功则跳出
    except Exception as e:
        retry_count += 1
        if retry_count >= max_retries:
            break  # 达到最大次数，退出循环

        # 1. 从配置源中排除已用过的源，取第一个未用源
        remaining_sources = [s for s in all_sources if s not in used_sources]
        if not remaining_sources:
            break  # 没有可用源可重试

        # 2. 用该源重新刮削，获取新的封面 URL
        fallback_json = scraping(number, sources=remaining_sources[0], ...)

        # 3. 记录已用源
        used_sources.add(new_site)

        # 4. 收集新刮削返回的 extrafanart
        if extrafanart in fallback_json:
            extrafanart_list.append(...)

        # 5. 如果拿到了新封面 URL，继续循环尝试下载
        if new_cover:
            cover_url = new_cover
            continue
```

#### 2.4 降级到 extrafanart

```python
if cache_cover_filepath is None and extrafanart_list:
    ef_url = extrafanart_list[0]          # 取第一张 extrafanart
    cache_cover_filepath = download_file(ef_url, number, proxy)
    cover_url = ef_url
```

如果全部重试后封面仍下载失败，且存在 extrafanart，则使用 extrafanart 第一张作为封面直接下载。

#### 2.5 回写最终封面 URL

```python
if cover_url:
    metamixed.cover = cover_url
    # 回写数据库，确保前端显示正确的封面 URL
    metadata_record = session.query(Metadata).filter(
        Metadata.number == metamixed.number
    ).order_by(Metadata.id.desc()).first()
    if metadata_record:
        metadata_record.cover = cover_url
        session.commit()
```

将实际使用的封面 URL 更新到内存对象和数据库 `Metadata` 表的 `cover` 字段。

#### 2.6 封面图片处理

```python
if cache_cover_filepath:
    # 有封面：正常处理（裁剪、生成 fanart/thumb/poster、添加水印）
    pics = process_cover(...)
    add_mark(...)
else:
    # 无封面：跳过封面图片处理，但继续执行 NFO 和文件转移
    logger.warning("封面获取失败，跳过封面图片处理")
```

无论封面是否获取成功，NFO 文件写入和视频文件转移都会正常执行。

## 流程图

```
刮削获取元数据
    │
    ▼
首次尝试下载封面 (cover_url = 首次刮削的 cover)
    │
    ├─ 成功 → 继续处理封面图片 → 完成
    │
    └─ 失败
        │
        ├─ 收集 extrafanart（首次刮削的 extrafanart_list）
        │
        ├─ retry_count < 5?
        │     │
        │     ├─ 否 → break
        │     │
        │     └─ 是 → 从剩余源中取第一个
        │                │
        │                ▼
        │         重新刮削获取新 cover
        │                │
        │                ├─ 失败/无 cover → break
        │                │
        │                └─ 成功
        │                    ├─ 记录新源到 used_sources
        │                    ├─ 收集 extrafanart
        │                    └─ cover_url = 新 cover → 继续循环
        │
        ▼
    全部重试失败，尝试 extrafanart
        │
        ├─ extrafanart_list 非空
        │     ├─ 下载 extrafanart[0] 成功 → cover_url = extrafanart[0]
        │     └─ 下载 extrafanart[0] 失败 → cover_url 不变
        │
        └─ extrafanart_list 为空 → cover_url 不变

回写 cover_url 到 metamixed.cover 和数据库 Metadata 表
    │
    ▼
封面图片处理（有则处理，无则跳过）
    │
    ▼
NFO 文件写入（始终执行）
    │
    ▼
视频文件转移（始终执行）
```

## 日志示例

```
✓ 元数据获取成功: ...
✓ NFO: MIDA-155 ...
✗ 封面下载失败 (尝试 1/5): https://.../bcxu_b.jpg — 403 Forbidden
⊘ 没有可用源可继续尝试
→ 使用 extrafanart 作为封面: https://pics.dmm.co.jp/.../mida00155jp-1.jpg
✓ 封面: MIDA-155...-poster.jpg (已裁剪)
✓ 刮削转移完成
```

## 注意事项

- `max_retries = 5` 硬编码，不可配置
- extrafanart 取列表第一个元素
- extrafanart 下载失败时使用 `crop_poster` 裁剪（若失败则直接使用原图），该逻辑复用 `process_cover`
- 数据库 `Metadata` 表的 `cover` 字段会被最终使用的 URL 更新，前端显示的封面 URL 即为实际可用的图片地址

