### PR TITLE
feat: 清理运行任务时对子任务进行 revoke

### DIFF
--- a/backend/bonita/api/routes/tasks.py
+++ b/backend/bonita/api/routes/tasks.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 from fastapi import APIRouter, HTTPException
 
-from bonita import schemas, main
+from bonita import schemas
 from bonita.api.deps import SessionDep
 from bonita.db.models.task import TransferConfig
 from bonita.celery_tasks.tasks import celery_transfer_entry, celery_transfer_group
@@ -50,7 +50,7 @@ async def run_transfer_task(
 
 @router.get("/status", response_model=list[schemas.TaskStatus])
 def get_all_tasks_status(
-    session: SessionDep, 
+    session: SessionDep,
     limit: int = 100
 ) -> Any:
     """ 获取所有任务状态
@@ -80,8 +80,8 @@ def get_all_tasks_status(
 
 @router.post("/cleanup/running", response_model=Response)
 def cleanup_running_tasks(session: SessionDep) -> Any:
-    """ 清理当前进行中的任务，批量标记为失败
+    """ 清理当前进行中的任务，批量标记为取消
     """
     celery_service = CeleryTaskService(session)
-    updated = celery_service.fail_active_tasks("被清理为失败")
-    return Response(success=True, message="已标记失败", data={"updated": updated})
+    updated = celery_service.revoke_active_tasks("被清理为取消")
+    return Response(success=True, message="已标记取消", data={"updated": updated})

--- a/backend/bonita/celery_tasks/decorators.py
+++ b/backend/bonita/celery_tasks/decorators.py
@@ -2,6 +2,7 @@ from functools import wraps
 from typing import Callable
 import logging
 
+from bonita.core.enums import TaskStatusEnum
 from bonita.services.celery_service import CeleryTaskService
 
 
@@ -12,6 +13,9 @@ def manage_celery_task(task_type: str):
     """
     Celery任务管理装饰器
     自动创建任务记录、更新进度、处理异常
+
+    则在创建记录后检查父任务状态：若父任务已被清理（REVOKED），
+    当前任务直接标记为 REVOKED 并跳过执行。
     """
     def decorator(func: Callable) -> Callable:
         @wraps(func)
@@ -21,6 +25,17 @@ def manage_celery_task(task_type: str):
             # 创建任务记录
             with CeleryTaskService() as task_service:
                 task_service.create_task(task_id, task_type)
+
+                # 若存在父任务且父任务已被清理，跳过执行
+                if self.request.parent_id:
+                    parent = task_service.get_task(self.request.parent_id)
+                    if parent and parent.status == TaskStatusEnum.REVOKED:
+                        task_service.revoke_task(task_id)
+                        logger.info(
+                            f"Task {task_id} ({task_type}) skipped: "
+                            f"parent {self.request.parent_id} has been revoked"
+                        )
+                        return []
 
             try:
                 # 执行原始任务

--- a/backend/bonita/services/celery_service.py
+++ b/backend/bonita/services/celery_service.py
@@ -99,16 +99,16 @@ class CeleryTaskService:
             CeleryTask.created_at.desc()
         ).offset(offset).limit(limit).all()
 
-    def fail_active_tasks(self, error_message: str = "被清理为失败") -> int:
+    def revoke_active_tasks(self, error_message: str = "被清理为取消") -> int:
         """
-        将当前处于等待或进行中的任务批量标记为失败。
+        将当前处于等待或进行中的任务批量标记为取消。
 
         返回受影响的任务数量。
         """
         updated_count = self.session.query(CeleryTask).filter(
             CeleryTask.status.in_([TaskStatusEnum.PENDING, TaskStatusEnum.PROGRESS])
         ).update({
-            CeleryTask.status: TaskStatusEnum.FAILURE,
+            CeleryTask.status: TaskStatusEnum.REVOKED,
             CeleryTask.error_message: error_message,
             CeleryTask.updatetime: datetime.now(),
         }, synchronize_session=False)


### PR DESCRIPTION
- 在清理任务接口中对 celery task 标记为取消而非失败，更符合实际含义，如果该任务有子任务，则后续的尚未运行的子任务也会标记为 revoke 并取消执行；